### PR TITLE
Get client id from api

### DIFF
--- a/PROJECT_LOCAL_SETUP.md
+++ b/PROJECT_LOCAL_SETUP.md
@@ -22,7 +22,7 @@ where:
 - `TODOIST_CLIENT_ID` value is the Client Id got from your [Todoist Application Console](https://developer.todoist.com/appconsole.html). It has to have the same value as in `background.js` file, in `BrowserExtension` directory.
 - `TODOIST_CLIENT_SECRET` value is the Secret Key got from your [Todoist Application Console](https://developer.todoist.com/appconsole.html).
 
-Regarding the extension part, the `TODOIST_CLIENT_ID` (and only it) is set in the header of `background.js`. Of course, `TODOIST_CLIENT_ID` in both Java and Javascript parts have to be equal.
+Regarding the extension part, the `TODOIST_CLIENT_ID` is automatically retrieved from API when launched.
 
 Both environment variables are required to launch Unit Tests AND to package the Java API, as they are injected in `appengine-web.xml` to make it working on Google Cloud Platform environment. *Yes, finally, the .war file contains a file with credentials values, but I did not find yet how to set Environment Variables on AppEngine Java 8 in another way.*          
 
@@ -33,6 +33,8 @@ See [Java API User Documentation](API_USER_DOCUMENTATION.md), to learn how to us
  
 
 ## How to test the extension ?
+
+**By default, the extension aims the API on TEST environment. Please look at URL at the very top of the file `background.js`.**
 
 Under your Firefox browser (**not yet tested under Chrome**) 
 - Open `about:debugging` tab 

--- a/TodoistProxyAPI/src/main/java/com/thug/model/GetClientIdResponse.java
+++ b/TodoistProxyAPI/src/main/java/com/thug/model/GetClientIdResponse.java
@@ -1,0 +1,14 @@
+package com.thug.model;
+
+public class GetClientIdResponse {
+
+    private String client_id;
+
+    public String getClientId() {
+        return this.client_id;
+    }
+
+    public void setClientId(String client_id) {
+        this.client_id = client_id;
+    }
+}

--- a/TodoistProxyAPI/src/test/java/com/thug/GetClientIdTest.java
+++ b/TodoistProxyAPI/src/test/java/com/thug/GetClientIdTest.java
@@ -1,0 +1,51 @@
+package com.thug;
+
+import com.google.api.server.spi.response.InternalServerErrorException;
+import com.thug.model.GetClientIdResponse;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+public class GetClientIdTest {
+
+    private static final Logger LOGGER = Logger.getLogger(GetClientIdTest.class.getName());
+
+    @Rule
+    public final EnvironmentVariables envVars = new EnvironmentVariables();
+
+    @Test
+    public void getClientId() throws InternalServerErrorException {
+
+        TodoistProxyAPI api = new TodoistProxyAPI();
+
+        GetClientIdResponse response = api.todoistClientId();
+
+        Pattern credentialsPattern = Pattern.compile("^[0-9a-f]{32}$");
+
+        Assert.assertNotNull(response);
+        Assert.assertFalse("Todoist Client ID property is not found", response.getClientId() == null);
+        Assert.assertFalse("Todoist Client ID property is not set", response.getClientId().length() == 0);
+        Assert.assertTrue("Todoist Client ID does not match pattern", credentialsPattern.matcher(response.getClientId()).matches());
+    }
+
+    @Test
+    public void getClientIdWithBadEnvVar() throws InternalServerErrorException {
+
+        TodoistProxyAPI api = new TodoistProxyAPI();
+        api.setClientId(null);
+
+        try {
+
+            GetClientIdResponse response = api.todoistClientId();
+            Assert.fail("Should have thrown an exception.");
+
+        } catch (InternalServerErrorException ex) {
+
+            Assert.assertEquals("Environment Variable TODOIST_CLIENT_ID is not set.", ex.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Regarding #43, this PR adds a new service on API to provide the Todoist Client ID to the extension, by a call made at the extension launching. The extension does not contain anymore Client ID configuration and make both extension and API more manageable as only one part contains the configuration.