### PR TITLE
Keeping Google App Engine always alive

### DIFF
--- a/.github/workflows/auto-deploy-api.yml
+++ b/.github/workflows/auto-deploy-api.yml
@@ -32,7 +32,6 @@ jobs:
         TODOIST_CLIENT_SECRET: ${{ secrets.TODOIST_CLIENT_SECRET_PROD }}
 
 
-    
     - name: GCP / Install gcloud SDK
       run: |
         sudo apt-get update && sudo apt-get install google-cloud-sdk && sudo apt-get install google-cloud-sdk-app-engine-java
@@ -54,8 +53,12 @@ jobs:
       run: |
         gcloud app deploy TodoistProxyAPI/target/TodoistQuickWebSiteURLAddAsTask-1.0-SNAPSHOT/WEB-INF/appengine-web.xml --quiet
 
-
+    - name: GCP / Deploy Cron on TEST env
+      run: |
+        gcloud app deploy TodoistProxyAPI/target/TodoistQuickWebSiteURLAddAsTask-1.0-SNAPSHOT/WEB-INF/cron.yaml
         
+
+
     - name: Build with Maven for a PROD env
       if: github.ref == 'refs/heads/master'
       run: mvn clean package --file TodoistProxyAPI/pom.xml -P PROD
@@ -82,3 +85,8 @@ jobs:
       if: github.ref == 'refs/heads/master'  
       run: |
         gcloud app deploy TodoistProxyAPI/target/TodoistQuickWebSiteURLAddAsTask-1.0-SNAPSHOT/WEB-INF/appengine-web.xml --quiet
+
+    - name: GCP / Deploy Cron on PROD env
+      if: github.ref == 'refs/heads/master'  
+      run: |
+        gcloud app deploy TodoistProxyAPI/target/TodoistQuickWebSiteURLAddAsTask-1.0-SNAPSHOT/WEB-INF/cron.yaml

--- a/.github/workflows/auto-deploy-api.yml
+++ b/.github/workflows/auto-deploy-api.yml
@@ -58,6 +58,7 @@ jobs:
         gcloud app deploy TodoistProxyAPI/target/TodoistQuickWebSiteURLAddAsTask-1.0-SNAPSHOT/WEB-INF/cron.yaml
         
 
+
     - name: Build with Maven for a PROD env
       if: github.ref == 'refs/heads/master'
       run: mvn clean package --file TodoistProxyAPI/pom.xml -P PROD

--- a/.github/workflows/auto-deploy-api.yml
+++ b/.github/workflows/auto-deploy-api.yml
@@ -58,7 +58,6 @@ jobs:
         gcloud app deploy TodoistProxyAPI/target/TodoistQuickWebSiteURLAddAsTask-1.0-SNAPSHOT/WEB-INF/cron.yaml
         
 
-
     - name: Build with Maven for a PROD env
       if: github.ref == 'refs/heads/master'
       run: mvn clean package --file TodoistProxyAPI/pom.xml -P PROD

--- a/API_DEPLOYMENT.md
+++ b/API_DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Build, package and deploy the project
 
-By default, a commit on the GitHub repository (today all branches, tomorrow only on `master`) will activate an auto-deployment of the Java API to Google Cloud Platform AppEngine, using GitHub Actions, on an TEST Environment. The workflow is run only if a file in the API directory `TodoistProxyAPI` is changed.    
+By default, a commit on the GitHub repository (today all branches, tomorrow only on `master`) will activate an auto-deployment of the Java API to Google Cloud Platform AppEngine, using GitHub Actions, on an TEST Environment. The workflow is run only if a file in the API directory `TodoistProxyAPI` is changed (or if the GitHub Actions workflow is modified).    
 
 The deployment workflow is described in `.github/workflows/auto-deploy-api.yml`.
 
@@ -39,6 +39,11 @@ If you have only modified the Java code itself, without modifying the API contra
     
     mvn appengine:deploy
 
+To deploy Cron tasks on GCP environment, you have to execute the following command:
+
+    gcloud app deploy cron.yaml
+
+where `cron.yaml` is found in `src/main/webapp/WEB-INF` folder. It is even more secure to use the compiled version of the file, what can be found in `target` folder, in case there is Maven injected variable (it is not the case when this line is written).
 
 ## On Google Cloud Platform PROD Environment
 
@@ -66,6 +71,12 @@ If you have only modified the Java code itself, without modifying the API contra
     mvn appengine:deploy ***-P PROD***
 
 Always test the deployment to be sure all is right.
+
+To deploy Cron tasks on GCP environment, you have to execute the following command:
+
+    gcloud app deploy cron.yaml
+
+where `cron.yaml` is found in `src/main/webapp/WEB-INF` folder. It is even more secure to use the compiled version of the file, what can be found in `target` folder, in case there is Maven injected variable (it is not the case when this line is written).
 
 ## On your own Google Cloud Platform Environment
 

--- a/API_DEPLOYMENT.md
+++ b/API_DEPLOYMENT.md
@@ -59,16 +59,16 @@ If the result is not `websitequickadding4todoistprod`, you can set it with:
 
 You can then build and deploy the Java API:  
 
-    mvn clean package ***-P PROD***  
-    mvn endpoints-framework:openApiDocs ***-P PROD***  
+    mvn clean package -P PROD  
+    mvn endpoints-framework:openApiDocs -P PROD  
     gcloud endpoints services deploy target/openapi-docs/openapi.json   
-    mvn appengine:deploy ***-P PROD***
+    mvn appengine:deploy -P PROD
 
 > Note that we use the Maven profiles to modify the inner configuration. Do not forget to active the PROD Profile on each of your Maven command.
 
 If you have only modified the Java code itself, without modifying the API contract, you can only execute:
 
-    mvn appengine:deploy ***-P PROD***
+    mvn appengine:deploy -P PROD
 
 Always test the deployment to be sure all is right.
 

--- a/API_USER_DOCUMENTATION.md
+++ b/API_USER_DOCUMENTATION.md
@@ -94,3 +94,12 @@ In case of success, service returns:
     {
         "message": "Let me sleeping..."
     }  
+
+
+# Cron tasks
+
+By default, the GCP Standard environment, used for this project, shuts down Google App Engine application if is not used. It is a problem when a user comes after the shutdown and suffers a 20-second-long process to wake up the API. To prevent this default, a Cron task has been configured to keep the API alive. It consists in a call each 5 minutes on the `Wake Up` service, doing nothing but returning a message asking to let it sleeping.  
+
+Cron task is injected into Google App Engine using the file `cron.yaml` which can be found in `WEB-INF` folder. Please look at [API Deployment procedure](API_DEPLOYMENT.md#On-Google-Cloud-Platform-TEST-Environment) to know how to deploy tasks on environment.  
+
+Be careful about GCP environment, as the default Google App Engine free time quota can be easily consumed with deployments added to the 24-hours alive execution.

--- a/API_USER_DOCUMENTATION.md
+++ b/API_USER_DOCUMENTATION.md
@@ -75,3 +75,22 @@ In case of success, service returns:
     {
         "clientId": "51ba8ae54c9146be848bd0561003f089"
     }  
+
+
+## wake-up GET
+
+### request body
+
+> no body
+
+### response codes
+
+- 200 : returns a valid client id configuration
+
+### response body
+
+In case of success, service returns:  
+
+    {
+        "message": "Let me sleeping..."
+    }  

--- a/TodoistProxyAPI/src/main/java/com/thug/TodoistProxyAPI.java
+++ b/TodoistProxyAPI/src/main/java/com/thug/TodoistProxyAPI.java
@@ -25,10 +25,10 @@ public class TodoistProxyAPI {
 
     protected static final String TODOIST_CLIENT_ID_ENV_VAR_ID = "TODOIST_CLIENT_ID";
     protected static final String TODOIST_CLIENT_SECRET_ENV_VAR_ID = "TODOIST_CLIENT_SECRET";
+    protected static final String WAKE_UP_RESPONSE = "Let me sleeping...";
     private static final String TODOIST_GET_ACCESS_TOKEN_API = "https://todoist.com/oauth/access_token";
     private static final String TODOIST_REVOKE_ACCESS_TOKEN_API = "https://api.todoist.com/sync/v8/access_tokens/revoke";
     private static final Logger LOGGER = Logger.getLogger(TodoistProxyAPI.class.getName());
-
     private String clientId;
 
     private String clientSecret;
@@ -173,6 +173,13 @@ public class TodoistProxyAPI {
         GetConfigurationResponse response = new GetConfigurationResponse();
         response.setClientId(clientId);
 
+        return response;
+    }
+
+    @ApiMethod(path = "wake-up", httpMethod = ApiMethod.HttpMethod.GET)
+    public WakeUpResponse wakeUp() {
+        WakeUpResponse response = new WakeUpResponse();
+        response.setMessage(WAKE_UP_RESPONSE);
         return response;
     }
 }

--- a/TodoistProxyAPI/src/main/java/com/thug/model/WakeUpResponse.java
+++ b/TodoistProxyAPI/src/main/java/com/thug/model/WakeUpResponse.java
@@ -1,0 +1,14 @@
+package com.thug.model;
+
+public class WakeUpResponse {
+
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/TodoistProxyAPI/src/main/webapp/WEB-INF/cron.xml
+++ b/TodoistProxyAPI/src/main/webapp/WEB-INF/cron.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cronentries>
+    <cron>
+        <url>/wake-up</url>
+        <target>beta</target>
+        <description>make API always available</description>
+        <schedule>every 5 minutes</schedule>
+    </cron>
+</cronentries>

--- a/TodoistProxyAPI/src/main/webapp/WEB-INF/cron.xml
+++ b/TodoistProxyAPI/src/main/webapp/WEB-INF/cron.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<cronentries>
-    <cron>
-        <url>/api/todoistProxyAPI/v1/wake-up</url>
-        <target>beta</target>
-        <description>make API always available</description>
-        <schedule>every 5 minutes</schedule>
-    </cron>
-</cronentries>

--- a/TodoistProxyAPI/src/main/webapp/WEB-INF/cron.xml
+++ b/TodoistProxyAPI/src/main/webapp/WEB-INF/cron.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cronentries>
     <cron>
-        <url>/wake-up</url>
+        <url>/api/todoistProxyAPI/v1/wake-up</url>
         <target>beta</target>
         <description>make API always available</description>
         <schedule>every 5 minutes</schedule>

--- a/TodoistProxyAPI/src/main/webapp/WEB-INF/cron.yaml
+++ b/TodoistProxyAPI/src/main/webapp/WEB-INF/cron.yaml
@@ -1,0 +1,4 @@
+cron:
+  - description: "make API always available"
+    url: /api/todoistProxyAPI/v1/wake-up
+    schedule: every 5 mins

--- a/TodoistProxyAPI/src/test/java/com/thug/WakeUpTest.java
+++ b/TodoistProxyAPI/src/test/java/com/thug/WakeUpTest.java
@@ -1,0 +1,24 @@
+package com.thug;
+
+import com.google.api.server.spi.response.InternalServerErrorException;
+import com.thug.model.WakeUpResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.logging.Logger;
+
+public class WakeUpTest {
+
+    private static final Logger LOGGER = Logger.getLogger(WakeUpTest.class.getName());
+
+    @Test
+    public void wakeup() throws InternalServerErrorException {
+
+        TodoistProxyAPI api = new TodoistProxyAPI();
+        WakeUpResponse response = api.wakeUp();
+
+        Assert.assertNotNull("Wake Up Service's response must not be null", response);
+        Assert.assertNotNull("Wake Up Service's response message must not be null", response.getMessage());
+        Assert.assertEquals("Wake Up Service's response message is not the one expected", TodoistProxyAPI.WAKE_UP_RESPONSE, response.getMessage());
+    }
+}


### PR DESCRIPTION
By adding cron task on Google App Engine, we are now able to keep the API always alive on TEST & PROD environments. It makes the users able to reach API from the first call without a 20 second long wake up of the API.

Cron tasks are auto deploy through Github Actions on TEST & PROD environments.